### PR TITLE
A bug with weekday relative parsing

### DIFF
--- a/date_time_parser/src/date_parse.rs
+++ b/date_time_parser/src/date_parse.rs
@@ -62,18 +62,13 @@ impl DateParser {
                     return Some(now.checked_add_signed(d).unwrap());
                 }
                 DateExpr::DayInNWeeks(n, d) => {
-                    println!("Found week day reference in {} relative to {}", text, now);
                     let mut difference: i32 = (d.num_days_from_sunday() as i32)
                         - (now.weekday().num_days_from_sunday() as i32);
-                    println!("Initial difference is {}", difference);
                     if difference < 0 {
                         difference = 7 + difference;
-                        println!("Adjusted difference is {}", difference);
                     }
                     difference += 7 * (n as i32);
-                    println!("After next/prev adjustment, difference is {}", difference);
                     let dur = Duration::days(difference as i64);
-                    println!("Duration is {} and computed date is {}", dur, now.checked_add_signed(dur).unwrap());
                     return Some(now.checked_add_signed(dur).unwrap());
                 }
                 DateExpr::InNMonths(n) => {

--- a/date_time_parser/src/date_parse.rs
+++ b/date_time_parser/src/date_parse.rs
@@ -62,13 +62,18 @@ impl DateParser {
                     return Some(now.checked_add_signed(d).unwrap());
                 }
                 DateExpr::DayInNWeeks(n, d) => {
+                    println!("Found week day reference in {} relative to {}", text, now);
                     let mut difference: i32 = (d.num_days_from_sunday() as i32)
                         - (now.weekday().num_days_from_sunday() as i32);
+                    println!("Initial difference is {}", difference);
                     if difference < 0 {
                         difference = 7 - difference;
+                        println!("Adjusted difference is {}", difference);
                     }
                     difference += 7 * (n as i32);
+                    println!("After next/prev adjustment, difference is {}", difference);
                     let dur = Duration::days(difference as i64);
+                    println!("Duration is {} and computed date is {}", dur, now.checked_add_signed(dur).unwrap());
                     return Some(now.checked_add_signed(dur).unwrap());
                 }
                 DateExpr::InNMonths(n) => {

--- a/date_time_parser/src/date_parse.rs
+++ b/date_time_parser/src/date_parse.rs
@@ -67,7 +67,7 @@ impl DateParser {
                         - (now.weekday().num_days_from_sunday() as i32);
                     println!("Initial difference is {}", difference);
                     if difference < 0 {
-                        difference = 7 - difference;
+                        difference = 7 + difference;
                         println!("Adjusted difference is {}", difference);
                     }
                     difference += 7 * (n as i32);


### PR DESCRIPTION
Today is Friday, if I use the date parser with day names I get the following:

- "Friday" = Today (not sure I agree with this, but I accept it)
- "Saturday" = Tomorrow
- "Sunday" = +9 days (should be +2)
- "Monday" = +10 days (should be +3)
- etc

The root cause is a minus sign where there should be a plus sign.

First commit, adds some `println!` logging, second fixes the issue and third commit removes the logging. So overall just a single character change.