### PR TITLE
Replace usage of NaiveTime::from_hms with NaiveTime::from_hms_opt

### DIFF
--- a/date_time_parser/src/date_parse.rs
+++ b/date_time_parser/src/date_parse.rs
@@ -38,7 +38,7 @@ impl DateParser {
     /// * `now` - A [`NaiveDate`](https://docs.rs/chrono/0.4.0/chrono/naive/struct.NaiveDate.html) to interpret the natural language date around
     ///
     /// # Example
-    /// 
+    ///
     /// ```
     /// use chrono::{prelude::*, Duration, Local, NaiveDate, NaiveDateTime, Weekday};
     /// use date_time_parser::{DateParser, Recognizable};

--- a/date_time_parser/src/lib.rs
+++ b/date_time_parser/src/lib.rs
@@ -53,8 +53,8 @@
 //! ```
 
 mod date_parse;
-mod time_parse;
 mod recognizable;
+mod time_parse;
 pub use date_parse::DateParser;
 pub use recognizable::Recognizable;
 pub use time_parse::TimeParser;

--- a/date_time_parser/src/time_parse.rs
+++ b/date_time_parser/src/time_parse.rs
@@ -125,7 +125,7 @@ fn parse_absolute_time(text: &str) -> Option<TimeExpr> {
             }
         }
 
-        return Some(TimeExpr::Absolute(NaiveTime::from_hms(hour, minute, 0)));
+        return Some(TimeExpr::Absolute(NaiveTime::from_hms_opt(hour, minute, 0)?));
     }
 
     None
@@ -150,7 +150,7 @@ fn parse_casual_time(text: &str) -> Option<TimeExpr> {
         // println!("match: {:?}", re.find(&text));
         if re.find(&text).is_some() {
             // println!("hour: {}", hours[i]);
-            return Some(TimeExpr::Absolute(NaiveTime::from_hms(hours[i], 0, 0)));
+            return Some(TimeExpr::Absolute(NaiveTime::from_hms_opt(hours[i], 0, 0)?));
         }
     }
 
@@ -245,9 +245,9 @@ mod time_expr_tests {
     fn assert_recognize_time(text: &str, expected_h: u32, expected_m: u32) {
         assert_eq!(
             TimeExpr::recognize(text),
-            Some(TimeExpr::Absolute(NaiveTime::from_hms(
+            Some(TimeExpr::Absolute(NaiveTime::from_hms_opt(
                 expected_h, expected_m, 0
-            )))
+            )?))
         )
     }
 

--- a/date_time_parser/src/time_parse.rs
+++ b/date_time_parser/src/time_parse.rs
@@ -125,7 +125,9 @@ fn parse_absolute_time(text: &str) -> Option<TimeExpr> {
             }
         }
 
-        return Some(TimeExpr::Absolute(NaiveTime::from_hms_opt(hour, minute, 0)?));
+        return Some(TimeExpr::Absolute(NaiveTime::from_hms_opt(
+            hour, minute, 0,
+        )?));
     }
 
     None
@@ -242,12 +244,19 @@ mod time_expr_tests {
         assert_in_hours_time("in 1 hour", 1);
     }
 
+    #[test]
+    fn invalid_time_tests() {
+        assert_eq!(TimeExpr::recognize(""), None);
+        assert_eq!(TimeExpr::recognize("24"), None);
+        assert_eq!(TimeExpr::recognize("99:99"), None);
+    }
+
     fn assert_recognize_time(text: &str, expected_h: u32, expected_m: u32) {
         assert_eq!(
             TimeExpr::recognize(text),
-            Some(TimeExpr::Absolute(NaiveTime::from_hms_opt(
+            Some(TimeExpr::Absolute(NaiveTime::from_hms(
                 expected_h, expected_m, 0
-            )?))
+            )))
         )
     }
 


### PR DESCRIPTION
All usages of from_hms where already returning an Option<T> so by using
from_hms_opt we avoid panics without having to change any function
signature.