### PR TITLE
Removed debug print

### DIFF
--- a/event_parser/src/lib.rs
+++ b/event_parser/src/lib.rs
@@ -171,7 +171,6 @@ pub fn to_event(text: &str) -> Event {
 
             e.starts(dt);
             e.ends(dt.checked_add_signed(Duration::hours(1)).unwrap()); // end is 1 hour after start
-            println!("date: {:?}", dt)
         }
         EventStartAndEndExpr::StartsAndEnds(start, end) => {
             // default to today


### PR DESCRIPTION
there was a print statement seemingly used for debugging left in the released version